### PR TITLE
build(devel): Improve browsing app source code

### DIFF
--- a/src/plone/develop.cfg
+++ b/src/plone/develop.cfg
@@ -14,6 +14,7 @@ parts +=
   xmltestreport
   coverage
   report
+  site-packages
 
 [configuration]
 eggs +=
@@ -54,3 +55,11 @@ eggs = coverage
 recipe = zc.recipe.egg
 eggs = coverage
 scripts = coverage=report
+
+[site-packages]
+# Reproduce a single directory tree of the Python packages installed in this buildout's
+# `rel_client` part.  Useful for searching, browsing, or otherwise exploring all the
+# source code involved in the application in a way that's more readable and avoids
+# duplicates from older versions of eggs.
+recipe = collective.recipe.omelette
+eggs = ${configuration:eggs}


### PR DESCRIPTION
Use `collective.recipe.omelette` to reproduce a single directory tree of the Python
packages installed in this buildout's `rel_client` part.  Useful for searching,
browsing, or otherwise exploring all the source code involved in the application in a
way that's more readable and avoids duplicates from older versions of eggs.

----

I tested this locally and it seems to work fine.  I'm also submitting this as my first
PR to learn the ropes on this project, so be sure to LMK what I should do differently!